### PR TITLE
Implement basic block management utilities

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -11,6 +11,7 @@ module universite_paris8.iut.dagnetti.junglequest {
     exports universite_paris8.iut.dagnetti.junglequest.modele.personnages;
     exports universite_paris8.iut.dagnetti.junglequest.modele.carte;
     exports universite_paris8.iut.dagnetti.junglequest.modele.donnees;
+    exports universite_paris8.iut.dagnetti.junglequest.modele.bloc;
     exports universite_paris8.iut.dagnetti.junglequest.vue.animation;
     exports universite_paris8.iut.dagnetti.junglequest.vue.utilitaire;
     opens universite_paris8.iut.dagnetti.junglequest.controleur.interfacefx to javafx.fxml;

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
@@ -11,6 +11,8 @@ import static universite_paris8.iut.dagnetti.junglequest.modele.donnees.Constant
 import universite_paris8.iut.dagnetti.junglequest.modele.carte.Carte;
 import universite_paris8.iut.dagnetti.junglequest.controleur.moteur.MoteurPhysique;
 import universite_paris8.iut.dagnetti.junglequest.modele.personnages.Joueur;
+import universite_paris8.iut.dagnetti.junglequest.modele.bloc.BlocManager;
+import universite_paris8.iut.dagnetti.junglequest.modele.bloc.TileType;
 import universite_paris8.iut.dagnetti.junglequest.vue.CarteAffichable;
 import universite_paris8.iut.dagnetti.junglequest.vue.VueBackground;
 import universite_paris8.iut.dagnetti.junglequest.vue.animation.GestionAnimation;
@@ -175,28 +177,34 @@ public class ControleurJeu {
         this.vueBackground = vueBackground;
     }
 
-    private void gererClicDroit(double xScene, double yScene){
+    private void gererClicDroit(double xScene, double yScene) {
         int colonne = (int) ((xScene + offsetX) / TAILLE_TUILE);
         int ligne = (int) (yScene / TAILLE_TUILE);
 
-        if (colonne < 0 || colonne >= carte.getLargeur() || ligne < 0 || ligne >= carte.getHauteur()){
+        if (colonne < 0 || colonne >= carte.getLargeur() || ligne < 0 || ligne >= carte.getHauteur()) {
             return;
         }
+
         String selection = inventaireController != null ? inventaireController.getItemSelectionne() : null;
-        if (selection != null && joueur.getInventaire().retirerItem(selection, 1));
-        carte.setValeurTuile(ligne, colonne, -1);
-        if (inventaireController != null){
-            inventaireController.deselectionner();
-            inventaireController.rafraichir();
-        }else { int id = carte.getValeurTuile(ligne, colonne);
-            if (id != Carte.TUILE_VIDE){
-                carte.setValeurTuile(ligne, colonne, Carte.TUILE_VIDE);
-                joueur.getInventaire().ajouterItem("Bois",1);
+
+        if (selection != null) {
+            if (joueur.getInventaire().retirerItem(selection, 1)) {
+                carte.setValeurTuile(ligne, colonne, TileType.VIDE.getId());
+            }
+            if (inventaireController != null) {
+                inventaireController.deselectionner();
+                inventaireController.rafraichir();
+            }
+        } else {
+            int idAvant = carte.getValeurTuile(ligne, colonne);
+            if (BlocManager.casserBloc(carte, ligne, colonne) && idAvant != Carte.TUILE_VIDE) {
+                joueur.getInventaire().ajouterItem("Bois", 1);
                 if (inventaireController != null) {
                     inventaireController.rafraichir();
                 }
             }
         }
+
         carteAffichable.redessiner(offsetX);
-        }
+    }
 }

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/bloc/BlocManager.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/bloc/BlocManager.java
@@ -1,0 +1,90 @@
+package universite_paris8.iut.dagnetti.junglequest.modele.bloc;
+
+import universite_paris8.iut.dagnetti.junglequest.modele.carte.Carte;
+
+import java.util.*;
+
+/**
+ * Méthodes utilitaires pour la manipulation des blocs de la carte
+ * (cassage, détection de groupes...).
+ */
+public final class BlocManager {
+
+    private BlocManager() {}
+
+    /**
+     * Casse un bloc et applique des règles spécifiques selon son type.
+     * <p>
+     * Exemple : si on casse un bloc de terre, l'herbe posée au-dessus est
+     * également retirée.
+     *
+     * @return {@code true} si quelque chose a été modifié
+     */
+    public static boolean casserBloc(Carte carte, int ligne, int colonne) {
+        int id = carte.getValeurTuile(ligne, colonne);
+        TileType type = TileType.fromId(id);
+        if (type == null || type == TileType.VIDE) {
+            return false;
+        }
+
+        switch (type) {
+            case TERRE -> {
+                supprimerHerbeAuDessus(carte, ligne, colonne);
+                carte.setValeurTuile(ligne, colonne, TileType.VIDE.getId());
+                return true;
+            }
+            default -> {
+                carte.setValeurTuile(ligne, colonne, TileType.VIDE.getId());
+                return true;
+            }
+        }
+    }
+
+    private static void supprimerHerbeAuDessus(Carte carte, int ligne, int colonne) {
+        int dessus = carte.getValeurTuile(ligne - 1, colonne);
+        if (dessus == TileType.HERBE.getId()) {
+            carte.setValeurTuile(ligne - 1, colonne, TileType.VIDE.getId());
+        }
+    }
+
+    /**
+     * Renvoie la liste des positions connectées (4 directions) ayant la même
+     * valeur que la tuile d'origine.
+     */
+    public static List<int[]> blocsConnectes(Carte carte, int ligne, int colonne) {
+        int cible = carte.getValeurTuile(ligne, colonne);
+        if (cible == TileType.VIDE.getId()) {
+            return List.of();
+        }
+        List<int[]> resultat = new ArrayList<>();
+        Deque<int[]> pile = new ArrayDeque<>();
+        Set<String> visite = new HashSet<>();
+        pile.push(new int[]{ligne, colonne});
+        visite.add(ligne + "," + colonne);
+
+        int[][] dirs = {{1,0}, {-1,0}, {0,1}, {0,-1}};
+        while (!pile.isEmpty()) {
+            int[] pos = pile.pop();
+            int l = pos[0];
+            int c = pos[1];
+            if (carte.getValeurTuile(l, c) != cible) {
+                continue;
+            }
+            resultat.add(pos);
+            for (int[] d : dirs) {
+                int nl = l + d[0];
+                int nc = c + d[1];
+                if (nl < 0 || nl >= carte.getHauteur() || nc < 0 || nc >= carte.getLargeur()) {
+                    continue;
+                }
+                if (carte.getValeurTuile(nl, nc) == cible) {
+                    String key = nl + "," + nc;
+                    if (visite.add(key)) {
+                        pile.push(new int[]{nl, nc});
+                    }
+                }
+            }
+        }
+        return resultat;
+    }
+}

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/bloc/TileType.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/bloc/TileType.java
@@ -1,0 +1,37 @@
+package universite_paris8.iut.dagnetti.junglequest.modele.bloc;
+
+/**
+ * Représente les différents types de tuiles manipulées par le jeu.
+ * Chaque type possède un identifiant entier présent dans la carte CSV.
+ */
+public enum TileType {
+    VIDE(-1),
+    HERBE(1),
+    TERRE(29),
+    ARBRE(129); // valeur indicative pour les troncs d'arbres
+
+    private final int id;
+
+    TileType(int id) {
+        this.id = id;
+    }
+
+    /**
+     * Identifiant numérique tel qu'il apparaît dans la carte.
+     */
+    public int getId() {
+        return id;
+    }
+
+    /**
+     * Retourne le type correspondant à l'identifiant fourni ou null si inconnu.
+     */
+    public static TileType fromId(int id) {
+        for (TileType t : values()) {
+            if (t.id == id) {
+                return t;
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/universite_paris8/iut/dagnetti/junglequest/modele/bloc/BlocManagerTest.java
+++ b/src/test/java/universite_paris8/iut/dagnetti/junglequest/modele/bloc/BlocManagerTest.java
@@ -1,0 +1,37 @@
+package universite_paris8.iut.dagnetti.junglequest.modele.bloc;
+
+import org.junit.jupiter.api.Test;
+import universite_paris8.iut.dagnetti.junglequest.modele.carte.Carte;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class BlocManagerTest {
+
+    @Test
+    void testCasserBlocTerreEnleveHerbeAuDessus() {
+        int[][] grille = {
+                {TileType.HERBE.getId()},
+                {TileType.TERRE.getId()}
+        };
+        Carte carte = new Carte(grille);
+        boolean modifie = BlocManager.casserBloc(carte, 1, 0);
+        assertTrue(modifie);
+        assertEquals(TileType.VIDE.getId(), carte.getValeurTuile(1,0));
+        assertEquals(TileType.VIDE.getId(), carte.getValeurTuile(0,0));
+    }
+
+    @Test
+    void testBlocsConnectes() {
+        int H = TileType.ARBRE.getId();
+        int[][] grille = {
+                {H, H, -1},
+                {H, -1, -1},
+                {-1, -1, -1}
+        };
+        Carte carte = new Carte(grille);
+        List<int[]> res = BlocManager.blocsConnectes(carte, 0, 0);
+        assertEquals(3, res.size());
+    }
+}


### PR DESCRIPTION
## Summary
- create `TileType` enum for block identifiers
- add `BlocManager` with helper functions to break blocks and find connected blocks
- update `ControleurJeu` to use the new manager when removing tiles
- export the new package in `module-info`
- add unit test for `BlocManager`

## Testing
- `mvnw -q test` *(fails: network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684982db86ec83338a5bfcdf1c400c98