### PR TITLE
Implement settings menu and improved tree removal

### DIFF
--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
@@ -5,6 +5,10 @@ import javafx.scene.Scene;
 import javafx.scene.image.ImageView;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.MouseButton;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
 
 import static universite_paris8.iut.dagnetti.junglequest.modele.donnees.ConstantesJeu.*;
 
@@ -18,6 +22,7 @@ import universite_paris8.iut.dagnetti.junglequest.vue.VueBackground;
 import universite_paris8.iut.dagnetti.junglequest.vue.animation.GestionAnimation;
 import javafx.scene.image.WritableImage;
 import universite_paris8.iut.dagnetti.junglequest.controleur.interfacefx.InventaireController;
+import universite_paris8.iut.dagnetti.junglequest.controleur.interfacefx.ParametresController;
 
 public class ControleurJeu {
 
@@ -35,6 +40,9 @@ public class ControleurJeu {
     private int frameMort = 0;
     private int frameSort = 0;
     private double offsetX = 0;
+
+    private boolean enPause = false;
+    private Stage fenetreParametres;
 
     /**
      * Initialise le contrôleur principal du jeu : clavier, animation, logique du joueur et gestion des clics.
@@ -80,6 +88,16 @@ public class ControleurJeu {
                 gererClicDroit(e.getX(), e.getY());
             } });
 
+        scene.addEventHandler(javafx.scene.input.KeyEvent.KEY_PRESSED, e -> {
+            if (e.getCode() == KeyCode.P) {
+                if (fenetreParametres == null) {
+                    ouvrirParametres(scene);
+                } else {
+                    fenetreParametres.close();
+                }
+            }
+        });
+
         // Lancement de la boucle de jeu
         new AnimationTimer() {
             @Override
@@ -93,6 +111,9 @@ public class ControleurJeu {
      * Méthode principale appelée à chaque frame pour gérer les actions du joueur et l'affichage.
      */
     private void mettreAJour() {
+        if (enPause) {
+            return;
+        }
         // Récupération des touches clavier pressées
         boolean gauche = clavier.estAppuyee(KeyCode.Q) || clavier.estAppuyee(KeyCode.LEFT);
         boolean droite = clavier.estAppuyee(KeyCode.D) || clavier.estAppuyee(KeyCode.RIGHT);
@@ -206,6 +227,26 @@ public class ControleurJeu {
             }
 
             carteAffichable.redessiner(offsetX);
+        }
+    }
+
+    private void ouvrirParametres(Scene scene) {
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource(
+                    "/universite_paris8/iut/dagnetti/junglequest/vue/interface/Parametres.fxml"));
+            Parent root = loader.load();
+            fenetreParametres = new Stage();
+            fenetreParametres.initOwner(scene.getWindow());
+            fenetreParametres.initModality(Modality.WINDOW_MODAL);
+            fenetreParametres.setTitle("Paramètres");
+            fenetreParametres.setScene(new Scene(root));
+            ParametresController controller = loader.getController();
+            controller.setStage(fenetreParametres);
+            enPause = true;
+            fenetreParametres.setOnHidden(e -> { enPause = false; fenetreParametres = null; });
+            fenetreParametres.show();
+        } catch (Exception e) {
+            e.printStackTrace();
         }
     }
 }

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/interfacefx/ParametresController.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/interfacefx/ParametresController.java
@@ -1,0 +1,43 @@
+package universite_paris8.iut.dagnetti.junglequest.controleur.interfacefx;
+
+import javafx.fxml.FXML;
+import javafx.fxml.Initializable;
+import javafx.scene.control.Slider;
+import javafx.stage.Stage;
+import universite_paris8.iut.dagnetti.junglequest.modele.donnees.ConstantesJeu;
+
+import java.net.URL;
+import java.util.ResourceBundle;
+
+/**
+ * Contrôleur de la fenêtre des paramètres du jeu.
+ * Permet de modifier la vitesse du joueur et la force du saut.
+ */
+public class ParametresController implements Initializable {
+
+    @FXML
+    private Slider sliderVitesse;
+    @FXML
+    private Slider sliderSaut;
+
+    private Stage stage;
+
+    @Override
+    public void initialize(URL location, ResourceBundle resources) {
+        sliderVitesse.setValue(ConstantesJeu.VITESSE_JOUEUR);
+        sliderSaut.setValue(ConstantesJeu.IMPULSION_SAUT);
+    }
+
+    public void setStage(Stage stage) {
+        this.stage = stage;
+    }
+
+    @FXML
+    private void fermer() {
+        ConstantesJeu.VITESSE_JOUEUR = (int) sliderVitesse.getValue();
+        ConstantesJeu.IMPULSION_SAUT = sliderSaut.getValue();
+        if (stage != null) {
+            stage.close();
+        }
+    }
+}

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/bloc/BlocManager.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/bloc/BlocManager.java
@@ -88,7 +88,8 @@ public final class BlocManager {
      */
     public static List<int[]> blocsConnectes(Carte carte, int ligne, int colonne) {
         int cible = carte.getValeurTuile(ligne, colonne);
-        if (cible == TileType.VIDE.getId()) {
+        TileType typeCible = TileType.fromId(cible);
+        if (typeCible == null || typeCible == TileType.VIDE) {
             return List.of();
         }
         List<int[]> resultat = new ArrayList<>();
@@ -102,7 +103,7 @@ public final class BlocManager {
             int[] pos = pile.pop();
             int l = pos[0];
             int c = pos[1];
-            if (carte.getValeurTuile(l, c) != cible) {
+            if (TileType.fromId(carte.getValeurTuile(l, c)) != typeCible) {
                 continue;
             }
             resultat.add(pos);
@@ -112,7 +113,7 @@ public final class BlocManager {
                 if (nl < 0 || nl >= carte.getHauteur() || nc < 0 || nc >= carte.getLargeur()) {
                     continue;
                 }
-                if (carte.getValeurTuile(nl, nc) == cible) {
+                if (TileType.fromId(carte.getValeurTuile(nl, nc)) == typeCible) {
                     String key = nl + "," + nc;
                     if (visite.add(key)) {
                         pile.push(new int[]{nl, nc});

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/donnees/ConstantesJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/donnees/ConstantesJeu.java
@@ -17,8 +17,8 @@ public final class ConstantesJeu {
     public static final int LARGEUR_JOUEUR = 56;
 
     // --- Mouvements et physique ---
-    /** Vitesse horizontale du joueur */
-    public static final int VITESSE_JOUEUR = 1;
+    /** Vitesse horizontale du joueur (modifiable via le menu de paramètres) */
+    public static int VITESSE_JOUEUR = 1;
 
     /** Accélération gravitationnelle appliquée chaque frame */
     public static final double GRAVITE = 0.5;
@@ -26,8 +26,8 @@ public final class ConstantesJeu {
     /** Vitesse verticale maximale en chute libre */
     public static final double VITESSE_CHUTE_MAX = 2;
 
-    /** Force de l’impulsion de saut du joueur */
-    public static final double IMPULSION_SAUT = 10;
+    /** Force de l’impulsion de saut du joueur (modifiable) */
+    public static double IMPULSION_SAUT = 10;
 
     // --- Animation ---
     /** Délai entre deux frames d’animation (en nombre de frames) */

--- a/src/main/resources/universite_paris8/iut/dagnetti/junglequest/vue/interface/Parametres.fxml
+++ b/src/main/resources/universite_paris8/iut/dagnetti/junglequest/vue/interface/Parametres.fxml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.Slider?>
+<?import javafx.scene.control.Button?>
+<VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
+      fx:controller="universite_paris8.iut.dagnetti.junglequest.controleur.interfacefx.ParametresController"
+      spacing="10" alignment="CENTER" stylesheets="@/universite_paris8/iut/dagnetti/junglequest/styles/inventaire.css"
+      padding="10">
+    <Label text="Vitesse du joueur" />
+    <Slider fx:id="sliderVitesse" min="0" max="5" blockIncrement="0.1" />
+    <Label text="Impulsion de saut" />
+    <Slider fx:id="sliderSaut" min="5" max="20" blockIncrement="0.5" />
+    <Button text="Fermer" onAction="#fermer" />
+</VBox>


### PR DESCRIPTION
## Summary
- allow runtime editing of player speed and jump impulse
- add parametre menu FXML and controller
- pause game with 'P' key to adjust settings
- fix BFS so entire tree is destroyed at once

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6849eb6d52ec833381c0d23a27710ce4