### PR TITLE
Raccourci clavier pour l'inventaire

### DIFF
--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
@@ -88,15 +88,13 @@ public class ControleurJeu {
                 gererClicDroit(e.getX(), e.getY());
             } });
 
-        // Appuyer sur 'P' permet d'ouvrir ou de fermer la fenêtre des paramètres
-        // du jeu. L'événement est écouté directement sur la scène afin de ne pas
-        // interférer avec la gestion classique du clavier.
+        // Appuyer sur 'P' permet d'afficher ou de masquer l'inventaire. L'événement
+        // est écouté directement sur la scène afin de ne pas interférer avec la
+        // gestion classique du clavier.
         scene.addEventHandler(javafx.scene.input.KeyEvent.KEY_PRESSED, e -> {
             if (e.getCode() == KeyCode.P) {
-                if (fenetreParametres == null) {
-                    ouvrirParametres(scene);
-                } else {
-                    fenetreParametres.close();
+                if (inventaireController != null) {
+                    inventaireController.basculerAffichage();
                 }
             } else if (e.getCode() == KeyCode.ENTER) {
                 enPause = !enPause;

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/interfacefx/InventaireController.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/interfacefx/InventaireController.java
@@ -135,4 +135,14 @@ public class InventaireController implements Initializable {
     public void deselectionner(){
         itemSelectionne = null;
     }
+
+    /**
+     * Affiche ou masque l'inventaire en conservant son emplacement dans la
+     * mise en page.
+     */
+    public void basculerAffichage() {
+        boolean visible = !slotBar.isVisible();
+        slotBar.setVisible(visible);
+        slotBar.setManaged(visible);
+    }
 }


### PR DESCRIPTION
## Summary
- add a visibility toggle in `InventaireController`
- use key `P` to show/hide the inventory

## Testing
- `mvn -q test` *(fails: PluginResolutionException)*

------
https://chatgpt.com/codex/tasks/task_e_684a15b71c3c83339bb62afcc1da23d9