### PR TITLE
Refactor controls and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# JungleQuest
+
+This project is a small JavaFX game. To run the game using Maven, use the Maven wrapper:
+
+```bash
+./mvnw javafx:run
+```
+
+The command downloads the required JavaFX dependencies and launches the main menu.
+
+Tests can be executed with:
+
+```bash
+./mvnw test
+```

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
@@ -93,6 +93,10 @@ public class ControleurJeu {
         // gestion classique du clavier.
         scene.addEventHandler(javafx.scene.input.KeyEvent.KEY_PRESSED, e -> {
             if (e.getCode() == KeyCode.P) {
+                if (fenetreParametres == null) {
+                    ouvrirParametres(scene);
+                }
+            } else if (e.getCode() == KeyCode.I) {
                 if (inventaireController != null) {
                     inventaireController.basculerAffichage();
                 }
@@ -212,8 +216,14 @@ public class ControleurJeu {
             String selection = inventaireController != null ? inventaireController.getItemSelectionne() : null;
 
             if (selection != null) {
-                if (joueur.getInventaire().retirerItem(selection, 1)) {
-                    carte.setValeurTuile(ligne, colonne, TileType.VIDE.getId());
+                TileType type = switch (selection.toLowerCase()) {
+                    case "bois" -> TileType.ARBRE;
+                    case "terre" -> TileType.TERRE;
+                    case "herbe" -> TileType.HERBE;
+                    default -> null;
+                };
+                if (type != null && joueur.getInventaire().retirerItem(selection, 1)) {
+                    carte.setValeurTuile(ligne, colonne, type.getId());
                 }
                 if (inventaireController != null) {
                     inventaireController.deselectionner();

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/demarrage/LanceurJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/demarrage/LanceurJeu.java
@@ -42,7 +42,14 @@ public class LanceurJeu extends Application {
         double largeur = ecran.getWidth();
         double hauteur = ecran.getHeight();
 
-        Pane racine = new Pane();
+        Pane racine;
+        try {
+            FXMLLoader loader = new FXMLLoader(getClass().getResource(
+                    "/universite_paris8/iut/dagnetti/junglequest/vue/VueJeu.fxml"));
+            racine = loader.load();
+        } catch (IOException e) {
+            racine = new Pane();
+        }
         Scene scene = new Scene(racine, largeur, hauteur);
 
         try {

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/carte/Carte.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/carte/Carte.java
@@ -67,7 +67,7 @@ public class Carte {
     /**
      * Retourne l'identifiant de la tuile à l'endroit donné.
      */
-public int getIdTuile(int ligne, int colonne) {
-return getValeurTuile(ligne, colonne);
-}
+    public int getIdTuile(int ligne, int colonne) {
+        return getValeurTuile(ligne, colonne);
+    }
 }

--- a/src/main/resources/universite_paris8/iut/dagnetti/junglequest/vue/VueJeu.fxml
+++ b/src/main/resources/universite_paris8/iut/dagnetti/junglequest/vue/VueJeu.fxml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.Pane?>
+<Pane fx:id="racine" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" />

--- a/src/test/java/universite_paris8/iut/dagnetti/junglequest/controleur/moteur/MoteurPhysiqueTest.java
+++ b/src/test/java/universite_paris8/iut/dagnetti/junglequest/controleur/moteur/MoteurPhysiqueTest.java
@@ -1,0 +1,43 @@
+package universite_paris8.iut.dagnetti.junglequest.controleur.moteur;
+
+import javafx.scene.image.ImageView;
+import org.junit.jupiter.api.Test;
+import universite_paris8.iut.dagnetti.junglequest.modele.bloc.TileType;
+import universite_paris8.iut.dagnetti.junglequest.modele.carte.Carte;
+import universite_paris8.iut.dagnetti.junglequest.modele.personnages.Joueur;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MoteurPhysiqueTest {
+
+    @Test
+    void testChuteEtCollisionSol() {
+        int[][] grille = {
+                {TileType.VIDE.getId()},
+                {TileType.TERRE.getId()}
+        };
+        Carte carte = new Carte(grille);
+        ImageView sprite = new ImageView();
+        sprite.setFitWidth(32);
+        sprite.setFitHeight(32);
+        Joueur joueur = new Joueur(sprite, 0, 0);
+        MoteurPhysique moteur = new MoteurPhysique();
+        moteur.mettreAJourPhysique(joueur, carte);
+        assertTrue(joueur.estAuSol());
+        assertEquals(0, joueur.getY());
+    }
+
+    @Test
+    void testChuteLibre() {
+        int[][] grille = {{TileType.VIDE.getId()}};
+        Carte carte = new Carte(grille);
+        ImageView sprite = new ImageView();
+        sprite.setFitWidth(32);
+        sprite.setFitHeight(32);
+        Joueur joueur = new Joueur(sprite, 0, 0);
+        MoteurPhysique moteur = new MoteurPhysique();
+        moteur.mettreAJourPhysique(joueur, carte);
+        assertFalse(joueur.estAuSol());
+        assertTrue(joueur.getY() > 0);
+    }
+}

--- a/src/test/java/universite_paris8/iut/dagnetti/junglequest/modele/carte/CarteTest.java
+++ b/src/test/java/universite_paris8/iut/dagnetti/junglequest/modele/carte/CarteTest.java
@@ -1,0 +1,44 @@
+package universite_paris8.iut.dagnetti.junglequest.modele.carte;
+
+import org.junit.jupiter.api.Test;
+import universite_paris8.iut.dagnetti.junglequest.modele.bloc.TileType;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CarteTest {
+
+    @Test
+    void testGetSetValeur() {
+        int[][] grille = {{0,1},{2,3}};
+        Carte carte = new Carte(grille);
+        assertEquals(1, carte.getValeurTuile(0,1));
+        carte.setValeurTuile(0,1,5);
+        assertEquals(5, carte.getValeurTuile(0,1));
+    }
+
+    @Test
+    void testIndicesInvalidesIgnorés() {
+        int[][] grille = {{0}};
+        Carte carte = new Carte(grille);
+        carte.setValeurTuile(-1,-1,4);
+        assertEquals(0, carte.getValeurTuile(0,0));
+        assertEquals(Carte.TUILE_VIDE, carte.getValeurTuile(2,2));
+    }
+
+    @Test
+    void testChercherLigneSol() {
+        int[][] grille = {
+                {TileType.VIDE.getId()},
+                {TileType.TERRE.getId()}
+        };
+        Carte carte = new Carte(grille);
+        assertEquals(1, carte.chercherLigneSol(0));
+    }
+
+    @Test
+    void testEstSolide() {
+        int[][] grille = {{TileType.VIDE.getId()}};
+        Carte carte = new Carte(grille);
+        assertFalse(carte.estSolide(0,0));
+    }
+}


### PR DESCRIPTION
## Summary
- add README with maven commands
- open parameters window with **P** and toggle inventory with **I**
- allow right-click block placement based on selected item
- load main layout from new `VueJeu.fxml`
- fix indentation in `Carte.getIdTuile`
- add unit tests for `Carte` and `MoteurPhysique`

## Testing
- `./mvnw test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684a1c82932883338a8879848651eeba