### PR TITLE
Add player health bar with damage key

### DIFF
--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
@@ -9,6 +9,7 @@ import javafx.fxml.FXMLLoader;
 import javafx.scene.Parent;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
+import javafx.scene.control.ProgressBar;
 
 import static universite_paris8.iut.dagnetti.junglequest.modele.donnees.ConstantesJeu.*;
 
@@ -33,6 +34,7 @@ public class ControleurJeu {
     private final GestionClavier clavier;
     private final GestionAnimation animation;
     private final InventaireController inventaireController;
+    private final ProgressBar barreVie;
     private VueBackground vueBackground;
     private final double largeurEcran;
 
@@ -47,7 +49,7 @@ public class ControleurJeu {
     /**
      * Initialise le contrôleur principal du jeu : clavier, animation, logique du joueur et gestion des clics.
      */
-    public ControleurJeu(Scene scene, Carte carte, CarteAffichable carteAffichable, Joueur joueur, InventaireController inventaireController,
+    public ControleurJeu(Scene scene, Carte carte, CarteAffichable carteAffichable, Joueur joueur, InventaireController inventaireController, ProgressBar barreVie,
                          WritableImage[] idle, WritableImage[] marche,
                          WritableImage[] attaque,
                          WritableImage[] preparationSaut, WritableImage[] volSaut, WritableImage[] sautReload,
@@ -59,6 +61,7 @@ public class ControleurJeu {
         this.carteAffichable = carteAffichable;
         this.joueur = joueur;
         this.inventaireController = inventaireController;
+        this.barreVie = barreVie;
         this.clavier = new GestionClavier(scene);
         this.largeurEcran = scene.getWidth();
 
@@ -133,6 +136,10 @@ public class ControleurJeu {
         boolean touchePreparationSaut = clavier.estAppuyee(KeyCode.DIGIT3);
         boolean toucheAtterrissage = clavier.estAppuyee(KeyCode.DIGIT4);
 
+        if (toucheDegats) {
+            joueur.subirDegats(1);
+        }
+
         // Déplacement horizontal
         if (gauche) {
             joueur.deplacerGauche(VITESSE_JOUEUR);
@@ -162,6 +169,9 @@ public class ControleurJeu {
             vueBackground.mettreAJourScroll(offsetX);
         }
         joueur.getSprite().setX(joueur.getX() - offsetX);
+        barreVie.setLayoutX(joueur.getX() - offsetX);
+        barreVie.setLayoutY(joueur.getY() - 10);
+        barreVie.setProgress(joueur.getPointsDeVie() / (double) VIE_MAX_JOUEUR);
 
         // Gestion des animations
         ImageView sprite = joueur.getSprite();

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/demarrage/LanceurJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/demarrage/LanceurJeu.java
@@ -97,9 +97,15 @@ public class LanceurJeu extends Application {
 
             Joueur joueur = new Joueur(spriteJoueur, xInitial, yInitial);
             racine.getChildren().addAll(carteAffichable, spriteJoueur);
+            javafx.scene.control.ProgressBar barreVie = new javafx.scene.control.ProgressBar(1.0);
+            barreVie.setPrefWidth(ConstantesJeu.TAILLE_SPRITE);
+            barreVie.setPrefHeight(6);
+            barreVie.setStyle("-fx-accent: #e74c3c;");
+            barreVie.setViewOrder(-9);
+            racine.getChildren().add(barreVie);
             InventaireController inventaireCtrl = afficherInventaire(racine, joueur, largeur, hauteur);
 
-            ControleurJeu controleurJeu = new ControleurJeu(scene, carte, carteAffichable, joueur, inventaireCtrl,
+            ControleurJeu controleurJeu = new ControleurJeu(scene, carte, carteAffichable, joueur, inventaireCtrl, barreVie,
                     idle, marche, attaque, preparationSaut, volSaut, sautReload,
                     chute, atterrissage, degats, mort, sort, accroupi, bouclier);
 

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/donnees/ConstantesJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/donnees/ConstantesJeu.java
@@ -16,6 +16,9 @@ public final class ConstantesJeu {
     /** Largeur du joueur (en pixels, utilisée pour le centrage) */
     public static final int LARGEUR_JOUEUR = 56;
 
+    /** Quantité maximale de points de vie du joueur */
+    public static final int VIE_MAX_JOUEUR = 100;
+
     // --- Mouvements et physique ---
     /** Vitesse horizontale du joueur (modifiable via le menu de paramètres) */
     public static int VITESSE_JOUEUR = 1;

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/personnages/Joueur.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/personnages/Joueur.java
@@ -2,6 +2,7 @@ package universite_paris8.iut.dagnetti.junglequest.modele.personnages;
 
 import javafx.scene.image.ImageView;
 import universite_paris8.iut.dagnetti.junglequest.modele.item.Inventaire;
+import universite_paris8.iut.dagnetti.junglequest.modele.donnees.ConstantesJeu;
 
 /**
  * Représente le joueur du jeu, héritant du comportement de base d’un personnage.
@@ -10,11 +11,13 @@ public class Joueur extends Personnage {
 
     private boolean estEnAttaque;
     private final Inventaire inventaire;
+    private int pointsDeVie;
 
     public Joueur(ImageView sprite, double x, double y) {
         super(sprite, x, y);
         this.estEnAttaque = false;
         this.inventaire = new Inventaire();
+        this.pointsDeVie = ConstantesJeu.VIE_MAX_JOUEUR;
     }
 
     public boolean estEnAttaque() {
@@ -31,5 +34,20 @@ public class Joueur extends Personnage {
 
     public Inventaire getInventaire() {
         return inventaire;
+    }
+
+    public int getPointsDeVie() {
+        return pointsDeVie;
+    }
+
+    public void subirDegats(int quantite) {
+        pointsDeVie -= quantite;
+        if (pointsDeVie < 0) {
+            pointsDeVie = 0;
+        }
+    }
+
+    public void soigner(int quantite) {
+        pointsDeVie = Math.min(pointsDeVie + quantite, ConstantesJeu.VIE_MAX_JOUEUR);
     }
 }


### PR DESCRIPTION
## Summary
- add a `VIE_MAX_JOUEUR` constant
- give `Joueur` hit points and methods to lose/gain life
- display a `ProgressBar` above the player and update it in the game loop
- simulate damage when pressing key `1`

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684ac407af1c833388985c23554b5471