### PR TITLE
Add collisions and inventory slots

### DIFF
--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
@@ -41,7 +41,6 @@ public class ControleurJeu {
 
     private int compteurAttaque = 0;
     private int frameMort = 0;
-    private int frameSort = 0;
     private double offsetX = 0;
 
     private boolean joueurMort = false;
@@ -134,20 +133,26 @@ public class ControleurJeu {
         boolean toucheAccroupi = clavier.estAppuyee(KeyCode.CONTROL);
         boolean toucheBouclier = clavier.estAppuyee(KeyCode.SHIFT);
         boolean toucheDegats = clavier.estAppuyee(KeyCode.M);
-        boolean toucheMort = clavier.estAppuyee(KeyCode.DIGIT2);
-        boolean toucheSort = clavier.estAppuyee(KeyCode.E);
-        boolean touchePreparationSaut = clavier.estAppuyee(KeyCode.DIGIT3);
-        boolean toucheAtterrissage = clavier.estAppuyee(KeyCode.DIGIT4);
+
+        // Gestion de la sélection des objets de l'inventaire
+        if (inventaireController != null) {
+            if (clavier.estAppuyee(KeyCode.DIGIT1)) inventaireController.selectionnerIndex(0);
+            else if (clavier.estAppuyee(KeyCode.DIGIT2)) inventaireController.selectionnerIndex(1);
+            else if (clavier.estAppuyee(KeyCode.DIGIT3)) inventaireController.selectionnerIndex(2);
+            else if (clavier.estAppuyee(KeyCode.DIGIT4)) inventaireController.selectionnerIndex(3);
+            else if (clavier.estAppuyee(KeyCode.DIGIT5)) inventaireController.selectionnerIndex(4);
+            else if (clavier.estAppuyee(KeyCode.DIGIT6)) inventaireController.selectionnerIndex(5);
+            else if (clavier.estAppuyee(KeyCode.DIGIT7)) inventaireController.selectionnerIndex(6);
+            else if (clavier.estAppuyee(KeyCode.DIGIT8)) inventaireController.selectionnerIndex(7);
+            else if (clavier.estAppuyee(KeyCode.DIGIT9)) inventaireController.selectionnerIndex(8);
+            if (clavier.estAppuyee(KeyCode.E)) inventaireController.deselectionner();
+        }
 
         if (toucheDegats) {
             joueur.subirDegats(1);
         }
 
         if (joueur.getPointsDeVie() <= 0) {
-            joueurMort = true;
-        }
-
-        if (toucheMort) {
             joueurMort = true;
         }
 
@@ -206,14 +211,6 @@ public class ControleurJeu {
             return;
         } else if (toucheDegats) {
             animation.animerDegats(sprite);
-        } else if (toucheSort) {
-            animation.animerSort(sprite, frameSort++);
-            if (frameSort >= 8) frameSort = 0;
-        } else if (touchePreparationSaut) {
-            animation.animerIdle(sprite, DELAI_FRAME);
-            animation.animerPreparationSaut(sprite);
-        } else if (toucheAtterrissage) {
-            animation.animerAtterrissage(sprite);
         } else if (joueur.estEnAttaque()) {
             animation.animerAttaque(sprite, DELAI_FRAME, () -> joueur.finAttaque());
             compteurAttaque++;

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/ControleurJeu.java
@@ -174,7 +174,7 @@ public class ControleurJeu {
             joueur.sauter(IMPULSION_SAUT);
         }
 
-        moteur.mettreAJourPhysique(joueur, carte);
+        boolean aAtterri = moteur.mettreAJourPhysique(joueur, carte);
         offsetX = joueur.getX() - largeurEcran / 2;
         if (offsetX < 0) offsetX = 0;
         double maxOffset = carte.getLargeur() * TAILLE_TUILE -largeurEcran;
@@ -216,6 +216,8 @@ public class ControleurJeu {
             compteurAttaque++;
         } else if (!joueur.estAuSol()) {
             animation.animerSaut(sprite, joueur.getVitesseY());
+        } else if (aAtterri) {
+            animation.animerAtterrissage(sprite);
         } else if (toucheAccroupi) {
             animation.animerAccroupi(sprite);
         } else if (toucheBouclier) {

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/interfacefx/InventaireController.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/interfacefx/InventaireController.java
@@ -12,6 +12,8 @@ import universite_paris8.iut.dagnetti.junglequest.modele.item.Inventaire;
 
 import java.net.URL;
 import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.ResourceBundle;
 
 public class InventaireController implements Initializable {
@@ -20,6 +22,7 @@ public class InventaireController implements Initializable {
     private HBox slotBar;
     private Inventaire inventaire;
     private String itemSelectionne;
+    private List<String> ordreItems = new ArrayList<>();
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
@@ -42,6 +45,7 @@ public class InventaireController implements Initializable {
         if (inventaire == null) {
             System.err.println("Inventaire non initialisé (null).");
         } else {
+            ordreItems = new ArrayList<>(inventaire.getItems().keySet());
             afficherSlots();
             itemSelectionne = null;
             System.out.println("Inventaire appliqué au contrôleur. Contenu : " + inventaire.getItems().size() + " item(s).");
@@ -54,20 +58,22 @@ public class InventaireController implements Initializable {
     private void afficherSlots() {
         slotBar.getChildren().clear();
 
-        //  Affichage des objets possédés
-        for (Map.Entry<String, Integer> entry : inventaire.getItems().entrySet()) {
-            String nom = entry.getKey();
-            int quantite = entry.getValue();
+        // Slot fixe pour l'épée
+        StackPane slotEpee = creerSlotEpee();
+        slotBar.getChildren().add(slotEpee);
 
+        //  Affichage des objets possédés dans l'ordre mémorisé
+        for (String nom : ordreItems) {
+            int quantite = inventaire.getItems().getOrDefault(nom, 0);
             StackPane slot = creerSlot(nom, quantite);
             slotBar.getChildren().add(slot);
         }
 
         // Complétion visuelle avec des slots vides
-        int slotsUtilisés = inventaire.getItems().size();
+        int slotsUtilises = ordreItems.size();
         int slotsTotaux = 9;
 
-        for (int i = slotsUtilisés; i < slotsTotaux; i++) {
+        for (int i = slotsUtilises; i < slotsTotaux; i++) {
             StackPane vide = creerSlotVide();
             slotBar.getChildren().add(vide);
         }
@@ -134,6 +140,25 @@ public class InventaireController implements Initializable {
     /**réinitialise la séléction d'item */
     public void deselectionner(){
         itemSelectionne = null;
+    }
+
+    /**
+     * Sélectionne l'objet à l'indice donné dans l'inventaire.
+     */
+    public void selectionnerIndex(int index) {
+        if (index >= 0 && index < ordreItems.size()) {
+            itemSelectionne = ordreItems.get(index);
+        }
+    }
+
+    private StackPane creerSlotEpee() {
+        StackPane slot = new StackPane();
+        slot.getStyleClass().add("slot-epee");
+        Label icon = new Label("\u2694"); // simple sword unicode
+        icon.setStyle("-fx-text-fill: white; -fx-font-size: 18px;");
+        slot.getChildren().add(icon);
+        slot.setOnMouseClicked(e -> itemSelectionne = null);
+        return slot;
     }
 
     /**

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/moteur/MoteurPhysique.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/moteur/MoteurPhysique.java
@@ -12,12 +12,14 @@ import universite_paris8.iut.dagnetti.junglequest.modele.bloc.TileType;
 public class MoteurPhysique {
 
     /**
-     * Applique la physique à un personnage : chute, collisions, position.
+     * Met à jour la physique d'un personnage et indique s'il vient d'atterrir.
      *
-     * @param personnage Le personnage à mettre à jour (ex. Joueur, Ennemi, etc.)
-     * @param carte      La carte contenant les tuiles solides
+     * @param personnage le personnage à mettre à jour
+     * @param carte      la carte pour les collisions
+     * @return {@code true} si le personnage vient d'atterrir lors de cette mise
+     *         à jour
      */
-    public void mettreAJourPhysique(Personnage personnage, Carte carte) {
+    public boolean mettreAJourPhysique(Personnage personnage, Carte carte) {
         // Appliquer la gravité
         personnage.appliquerGravite(ConstantesJeu.GRAVITE, ConstantesJeu.VITESSE_CHUTE_MAX);
 
@@ -55,7 +57,8 @@ public class MoteurPhysique {
         personnage.setX(newX);
 
         // --- Gestion des collisions verticales ---
-        personnage.setEstAuSol(false);
+        boolean auSolAvant = personnage.estAuSol();
+        boolean auSolApres = false;
         if (personnage.getVitesseY() > 0) { // chute
             int ligneBas = (int) ((newY + hauteur - 1) / ConstantesJeu.TAILLE_TUILE);
             int colGauche = (int) (newX / ConstantesJeu.TAILLE_TUILE);
@@ -65,7 +68,7 @@ public class MoteurPhysique {
                 if (carte.estSolide(ligneBas, c) && TileType.fromId(id) != TileType.ARBRE) {
                     newY = ligneBas * ConstantesJeu.TAILLE_TUILE - hauteur;
                     personnage.setVitesseY(0);
-                    personnage.setEstAuSol(true);
+                    auSolApres = true;
                     break;
                 }
             }
@@ -81,8 +84,20 @@ public class MoteurPhysique {
                     break;
                 }
             }
+        } else {
+            int ligneBas = (int) ((newY + hauteur - 1) / ConstantesJeu.TAILLE_TUILE);
+            int colGauche = (int) (newX / ConstantesJeu.TAILLE_TUILE);
+            int colDroite = (int) ((newX + largeur - 1) / ConstantesJeu.TAILLE_TUILE);
+            for (int c = colGauche; c <= colDroite; c++) {
+                int id = carte.getValeurTuile(ligneBas, c);
+                if (carte.estSolide(ligneBas, c) && TileType.fromId(id) != TileType.ARBRE) {
+                    auSolApres = true;
+                    break;
+                }
+            }
         }
-
         personnage.setY(newY);
+        personnage.setEstAuSol(auSolApres);
+        return !auSolAvant && auSolApres;
     }
 }

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/moteur/MoteurPhysique.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/controleur/moteur/MoteurPhysique.java
@@ -3,6 +3,7 @@ package universite_paris8.iut.dagnetti.junglequest.controleur.moteur;
 import universite_paris8.iut.dagnetti.junglequest.modele.donnees.ConstantesJeu;
 import universite_paris8.iut.dagnetti.junglequest.modele.carte.Carte;
 import universite_paris8.iut.dagnetti.junglequest.modele.personnages.Personnage;
+import universite_paris8.iut.dagnetti.junglequest.modele.bloc.TileType;
 
 /**
  * Gère les règles physiques élémentaires du jeu :
@@ -17,33 +18,71 @@ public class MoteurPhysique {
      * @param carte      La carte contenant les tuiles solides
      */
     public void mettreAJourPhysique(Personnage personnage, Carte carte) {
-        //  Appliquer la gravité uniquement si le personnage est en l'air
+        // Appliquer la gravité
         personnage.appliquerGravite(ConstantesJeu.GRAVITE, ConstantesJeu.VITESSE_CHUTE_MAX);
 
-        //  Coordonnées des pieds du personnage (centre bas du sprite)
-        double piedX = personnage.getX() + personnage.getSprite().getFitWidth() / 2;
-        double piedY = personnage.getY() + personnage.getSprite().getFitHeight();
+        double largeur = personnage.getSprite().getFitWidth();
+        double hauteur = personnage.getSprite().getFitHeight();
 
-        int colonne = (int) (piedX / ConstantesJeu.TAILLE_TUILE);
-        int ligne = (int) (piedY / ConstantesJeu.TAILLE_TUILE);
+        double newX = personnage.getX() + personnage.getVitesseX();
+        double newY = personnage.getY() + personnage.getVitesseY();
 
-        // Vérifier si le sol est solide sous les pieds
-        if (carte.estSolide(ligne, colonne)) {
-            double ySol = ligne * ConstantesJeu.TAILLE_TUILE;
-
-            // Si le personnage tombe et dépasse le sol : poser au sol
-            if (personnage.getVitesseY() >= 0 && piedY >= ySol) {
-                personnage.poserAuSol(ySol - personnage.getSprite().getFitHeight());
-
-                //System.out.println("Collision au sol détectée → personnage posé à y=" + personnage.getY());
+        // --- Gestion des collisions horizontales ---
+        if (personnage.getVitesseX() > 0) { // vers la droite
+            int col = (int) ((newX + largeur - 1) / ConstantesJeu.TAILLE_TUILE);
+            int top = (int) (personnage.getY() / ConstantesJeu.TAILLE_TUILE);
+            int bottom = (int) ((personnage.getY() + hauteur - 1) / ConstantesJeu.TAILLE_TUILE);
+            for (int l = top; l <= bottom; l++) {
+                if (carte.estSolide(l, col)) {
+                    newX = col * ConstantesJeu.TAILLE_TUILE - largeur;
+                    personnage.setVitesseX(0);
+                    break;
+                }
             }
-        } else {
-            // Aucun sol détecté
-            personnage.setEstAuSol(false);
-            //System.out.println("Personnage en l'air, gravité appliquée. y=" + personnage.getY() + ", vY=" + personnage.getVitesseY());
+        } else if (personnage.getVitesseX() < 0) { // vers la gauche
+            int col = (int) (newX / ConstantesJeu.TAILLE_TUILE);
+            int top = (int) (personnage.getY() / ConstantesJeu.TAILLE_TUILE);
+            int bottom = (int) ((personnage.getY() + hauteur - 1) / ConstantesJeu.TAILLE_TUILE);
+            for (int l = top; l <= bottom; l++) {
+                if (carte.estSolide(l, col)) {
+                    newX = (col + 1) * ConstantesJeu.TAILLE_TUILE;
+                    personnage.setVitesseX(0);
+                    break;
+                }
+            }
         }
 
-        // Mise à jour finale de la position
-        personnage.mettreAJourPosition();
+        personnage.setX(newX);
+
+        // --- Gestion des collisions verticales ---
+        personnage.setEstAuSol(false);
+        if (personnage.getVitesseY() > 0) { // chute
+            int ligneBas = (int) ((newY + hauteur - 1) / ConstantesJeu.TAILLE_TUILE);
+            int colGauche = (int) (newX / ConstantesJeu.TAILLE_TUILE);
+            int colDroite = (int) ((newX + largeur - 1) / ConstantesJeu.TAILLE_TUILE);
+            for (int c = colGauche; c <= colDroite; c++) {
+                int id = carte.getValeurTuile(ligneBas, c);
+                if (carte.estSolide(ligneBas, c) && TileType.fromId(id) != TileType.ARBRE) {
+                    newY = ligneBas * ConstantesJeu.TAILLE_TUILE - hauteur;
+                    personnage.setVitesseY(0);
+                    personnage.setEstAuSol(true);
+                    break;
+                }
+            }
+        } else if (personnage.getVitesseY() < 0) { // saut
+            int ligneHaut = (int) (newY / ConstantesJeu.TAILLE_TUILE);
+            int colGauche = (int) (newX / ConstantesJeu.TAILLE_TUILE);
+            int colDroite = (int) ((newX + largeur - 1) / ConstantesJeu.TAILLE_TUILE);
+            for (int c = colGauche; c <= colDroite; c++) {
+                int id = carte.getValeurTuile(ligneHaut, c);
+                if (carte.estSolide(ligneHaut, c) && TileType.fromId(id) != TileType.ARBRE) {
+                    newY = (ligneHaut + 1) * ConstantesJeu.TAILLE_TUILE;
+                    personnage.setVitesseY(0);
+                    break;
+                }
+            }
+        }
+
+        personnage.setY(newY);
     }
 }

--- a/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/personnages/Personnage.java
+++ b/src/main/java/universite_paris8/iut/dagnetti/junglequest/modele/personnages/Personnage.java
@@ -110,4 +110,34 @@ public abstract class Personnage {
         this.estAuSol = auSol;
     }
 
+    /**
+     * Positionne le personnage horizontalement.
+     */
+    public void setX(double x) {
+        this.x = x;
+        this.sprite.setX(x);
+    }
+
+    /**
+     * Positionne le personnage verticalement.
+     */
+    public void setY(double y) {
+        this.y = y;
+        this.sprite.setY(y);
+    }
+
+    /**
+     * Modifie la vitesse horizontale du personnage.
+     */
+    public void setVitesseX(double vitesseX) {
+        this.vitesseX = vitesseX;
+    }
+
+    /**
+     * Modifie la vitesse verticale du personnage.
+     */
+    public void setVitesseY(double vitesseY) {
+        this.vitesseY = vitesseY;
+    }
+
 }

--- a/src/main/resources/universite_paris8/iut/dagnetti/junglequest/styles/inventaire.css
+++ b/src/main/resources/universite_paris8/iut/dagnetti/junglequest/styles/inventaire.css
@@ -40,3 +40,15 @@
     -fx-effect: dropshadow(gaussian, rgba(140,255,140,0.5), 6, 0.2, 0, 0);
 }
 
+.slot-epee {
+    -fx-background-color: rgba(26,26,26,0.8);
+    -fx-border-color: gold;
+    -fx-border-width: 2;
+    -fx-border-radius: 8;
+    -fx-background-radius: 8;
+    -fx-pref-width: 44;
+    -fx-pref-height: 44;
+    -fx-alignment: center;
+    -fx-padding: 0 12 0 0;
+}
+

--- a/src/test/java/universite_paris8/iut/dagnetti/junglequest/controleur/moteur/MoteurPhysiqueTest.java
+++ b/src/test/java/universite_paris8/iut/dagnetti/junglequest/controleur/moteur/MoteurPhysiqueTest.java
@@ -22,7 +22,8 @@ public class MoteurPhysiqueTest {
         sprite.setFitHeight(32);
         Joueur joueur = new Joueur(sprite, 0, 0);
         MoteurPhysique moteur = new MoteurPhysique();
-        moteur.mettreAJourPhysique(joueur, carte);
+        boolean atterri = moteur.mettreAJourPhysique(joueur, carte);
+        assertTrue(atterri);
         assertTrue(joueur.estAuSol());
         assertEquals(0, joueur.getY());
     }
@@ -36,7 +37,8 @@ public class MoteurPhysiqueTest {
         sprite.setFitHeight(32);
         Joueur joueur = new Joueur(sprite, 0, 0);
         MoteurPhysique moteur = new MoteurPhysique();
-        moteur.mettreAJourPhysique(joueur, carte);
+        boolean atterri = moteur.mettreAJourPhysique(joueur, carte);
+        assertFalse(atterri);
         assertFalse(joueur.estAuSol());
         assertTrue(joueur.getY() > 0);
     }


### PR DESCRIPTION
## Summary
- handle horizontal and upward collisions in physics engine
- expose setters in `Personnage` for collision handling
- add sword slot and keyboard selection to inventory UI
- rework input in `ControleurJeu` to remove debug keys
- style dedicated sword slot in inventory

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684bbef83f6c833385176b39a9f79620